### PR TITLE
Using Label text for images

### DIFF
--- a/src/remote/content.js
+++ b/src/remote/content.js
@@ -205,6 +205,7 @@ function getContentBundle() {
         switch (blockItem.tagName) {
           case "IMG":
             data.src = blockItem.src;
+            data.text = blockItem.className;
             break;
           case "INPUT":
             data.type = blockItem.type;


### PR DESCRIPTION
Added ability to use a clickAfter function that uses the label text of an image based on its relationship to the object that precedes it.